### PR TITLE
chore: add checksum for the rootfs.tar.xz generated file

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -64,6 +64,7 @@ jobs:
             mkdir -p etc; touch etc/resolv.conf
             tar rf rootfs.tar --mode=644 --group=root --owner=root etc/resolv.conf
             xz rootfs.tar
+            shasum -a 256 rootfs.tar.xz > shasums
       - name: Bump version and push tag
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         id: tag_version
@@ -80,4 +81,4 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           bodyfile: changes
-          artifacts: "lastimage,rootfs.tar.xz,version"
+          artifacts: "lastimage,rootfs.tar.xz,shasums,version"


### PR DESCRIPTION
In order to embed the file in Podman Desktop, it'll nice to be able to verify the checksum of the downloaded file

I used the same format/pattern than on podman repository 

example:
https://github.com/containers/podman/releases/download/v4.3.1/shasums

Change-Id: I4da653647d7d00a22ec9da50c5b85046e855d8f0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>