### PR TITLE
gvproxy: Use pre-built 0.7.1 'vm' binary

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -57,16 +57,12 @@ jobs:
             echo "\`\`\`" >> changes
             echo "package_change=true" >> $GITHUB_OUTPUT
           fi
-      - name: Add gvproxy vm
+      - name: Add gvforwarder
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |
             set +o verbose
-            git clone https://github.com/containers/gvisor-tap-vsock
-            cd gvisor-tap-vsock
-            git checkout v0.6.1
-            make vm
-            podman cp bin/vm fedora-update:/usr/local/bin/vm  
-            cd ..
+            curl -L -O https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.1/gvforwarder
+            podman cp gvforwarder fedora-update:/usr/local/bin/vm
       - name: Prepare archive
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |


### PR DESCRIPTION
This upgrades to gvisor-tap-vsock 0.7.1, and uses the prebuilt 'vm'
binary (now called 'gvforwarder'). The binary is still copied to
/usr/local/bin/vm as changing its name requires podman code changes.