### PR TITLE
Revert "gvproxy: Use pre-built 0.7.1 'vm' binary"

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -57,12 +57,16 @@ jobs:
             echo "\`\`\`" >> changes
             echo "package_change=true" >> $GITHUB_OUTPUT
           fi
-      - name: Add gvforwarder
+      - name: Add gvproxy vm
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |
             set +o verbose
-            curl -L -O https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.1/gvforwarder
-            podman cp gvforwarder fedora-update:/usr/local/bin/vm
+            git clone https://github.com/containers/gvisor-tap-vsock
+            cd gvisor-tap-vsock
+            git checkout v0.6.1
+            make vm
+            podman cp bin/vm fedora-update:/usr/local/bin/vm  
+            cd ..
       - name: Prepare archive
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |


### PR DESCRIPTION
This reverts commit 49a561bc3637a5376f3f265c4e89f0e810802a62.

The PR is causing a failure when starting a podman machine using  user-mode-networking

example:
`podman machine init --user-mode-networking --now` 

error is coming from these lines
https://github.com/containers/podman/blob/d8c6ca6c1bbbdda7009cfd403199c2edfa668d60/pkg/machine/wsl/usermodenet.go#L164-L184

reverting the PR is working (I tried it there in a forked repository: https://github.com/benoitf/podman-wsl-fedora/releases/tag/v0.1.0)

fixes https://github.com/containers/podman-desktop/issues/5235
fixes https://github.com/containers/podman/issues/20982