### PR TITLE
gvforwarder: Use binary from fedora repos

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           podman start fedora-update
           podman exec fedora-update sh -c 'rpm -qa --qf "%-30{name} %{version}-%{release}\n" | sort' > pre-update
-          podman exec fedora-update sh -c 'dnf update -y && dnf -y install podman podman-docker procps-ng openssh-server net-tools iproute dhcp-client crun-wasm wasmedge-rt && dnf clean all && rm -rf /var/cache/yum'
+          podman exec fedora-update sh -c 'dnf update -y && dnf -y install podman podman-docker procps-ng openssh-server net-tools iproute dhcp-client crun-wasm wasmedge-rt gvisor-tap-vsock-gvforwarder && dnf clean all && rm -rf /var/cache/yum'
           podman exec fedora-update sh -c 'rpm -qa --qf "%-30{name} %{version}-%{release}\n" | sort' > post-update
 
           diff -u pre-update post-update > delta || delta=1
@@ -57,16 +57,11 @@ jobs:
             echo "\`\`\`" >> changes
             echo "package_change=true" >> $GITHUB_OUTPUT
           fi
-      - name: Add gvproxy vm
+      - name: Add gvforwarder compat symlink
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |
             set +o verbose
-            git clone https://github.com/containers/gvisor-tap-vsock
-            cd gvisor-tap-vsock
-            git checkout v0.6.1
-            make vm
-            podman cp bin/vm fedora-update:/usr/local/bin/vm  
-            cd ..
+            podman exec ln -s  /usr/bin/gvforwarder /usr/local/bin/vm
       - name: Prepare archive
         if: steps.get-image.outputs.image_change == 'true' || steps.check-updates.outputs.package_change == 'true'
         run: |


### PR DESCRIPTION
gvforwarder is packaged as an RPM in fedora repos, no need to build it
manually when generating the wsl image.

This is another take to achieve what
https://github.com/containers/podman-wsl-fedora/pull/17 tried to do before
being reverted, but in a better way :)

I don't know how to test these changes though, after the precedent in #17, we
need to proceed with extra care ;)